### PR TITLE
Added remainder narg type

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -27,11 +27,10 @@ func Store(p *Parser, f *Option, args ...string) ([]string, error) {
 			p.Namespace.Set(f.DestName, args[0])
 			return args[1:], nil
 		}
-	} else if strings.ContainsAny(f.ArgNum, "*+") == true {
+	} else if strings.ContainsAny(f.ArgNum, "*+rR") == true {
 		if f.ArgNum == "+" && len(args) == 0 {
 			return args, TooFewArgsErr{*f}
 		}
-
 		var values []interface{}
 		for len(args) > 0 {
 			if err := ValidateChoice(*f, args[0]); err != nil {
@@ -166,7 +165,7 @@ func Append(p *Parser, f *Option, args ...string) ([]string, error) {
 		} else {
 			appendValue(p, f, f.DefaultVal)
 		}
-	} else {
+	} else if strings.ContainsAny(f.ArgNum, "*+rR") == true {
 		if f.ArgNum == "+" && len(args) == 0 {
 			return args, MissingOneOrMoreArgsErr{*f}
 		}

--- a/option.go
+++ b/option.go
@@ -191,7 +191,7 @@ func (f *Option) GetUsage() string {
 		f.MetaVarText = []string{choices}
 	}
 
-	if strings.ContainsAny(f.ArgNum, "?*+") == false {
+	if strings.ContainsAny(f.ArgNum, "?*+rR") == false {
 		count := 0
 		max, err := strconv.Atoi(f.ArgNum)
 		if err != nil {
@@ -221,6 +221,14 @@ func (f *Option) GetUsage() string {
 				" [",
 				strings.ToUpper(f.MetaVarText[0]),
 				"]",
+			)
+		case "r":
+			fallthrough
+		case "R":
+			usage = append(
+				usage,
+				" ",
+				" ...",
 			)
 		case "+":
 			fallthrough
@@ -297,7 +305,7 @@ func (f *Option) MetaVar(meta string, metaSlice ...string) *Option {
 // or more arguments.
 func (f *Option) Nargs(nargs string) *Option {
 	// TODO: Allow "r"/"R" for remainder args
-	allowedChars := []string{"?", "*", "+"}
+	allowedChars := []string{"?", "*", "+", "r", "R"}
 	for _, char := range allowedChars {
 		if nargs == char {
 			f.ArgNum = char


### PR DESCRIPTION
Allows for the `r` and `R` (same thing) Narg types, specifying to use the remaining args after all other options have been parsed.
