### PR TITLE
working sub-parsers

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -102,13 +102,13 @@ func (err MissingOneOrMoreArgsErr) Error() string {
 	return fmt.Sprintf(msg, err.opt.DisplayName())
 }
 
-// MissingCommandErr indicated that commands were available, but none were used.
-type MissingCommandErr struct {
+// MissingParserErr indicated that commands were available, but none were used.
+type MissingParserErr struct {
 	Parsers map[string]*Parser
 }
 
-// Error will return a string error message for the MissingCommandErr
-func (err MissingCommandErr) Error() string {
+// Error will return a string error message for the MissingParserErr
+func (err MissingParserErr) Error() string {
 	var names []string
 	for name, _ := range err.Parsers {
 		names = append(names, name)

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,18 @@ func (err InvalidChoiceErr) Error() string {
 
 }
 
+// InvalidParserNameErr indicates that a Command name has already been assigned and cannot be re-assigned.
+type InvalidParserNameErr struct {
+	name string
+}
+
+// Error will return a string error message for the InvalidParserNameErr
+func (err InvalidParserNameErr) Error() string {
+	msg := "invalid command name \"%s\""
+	return fmt.Sprintf(msg, err.name)
+
+}
+
 // InvalidFlagNameErr indicates that an argument with the provided public name
 // not exist.
 type InvalidFlagNameErr struct {
@@ -88,6 +100,21 @@ type MissingOneOrMoreArgsErr struct {
 func (err MissingOneOrMoreArgsErr) Error() string {
 	msg := "%s: at least one argument requireds"
 	return fmt.Sprintf(msg, err.opt.DisplayName())
+}
+
+// MissingCommandErr indicated that commands were available, but none were used.
+type MissingCommandErr struct {
+	Parsers map[string]*Parser
+}
+
+// Error will return a string error message for the MissingCommandErr
+func (err MissingCommandErr) Error() string {
+	var names []string
+	for name, _ := range err.Parsers {
+		names = append(names, name)
+	}
+	msg := "must use an available command: %s"
+	return fmt.Sprintf(msg, join("", "{", join(",", names...), "}"))
 }
 
 // MissingOptionErr indicated that an option was required but is missing.

--- a/namespace.go
+++ b/namespace.go
@@ -27,6 +27,22 @@ func (n *Namespace) KeyExists(key string) bool {
 	return false
 }
 
+// merge will take all the values from the other, provided Namespace and copy
+// them to the current Namespace.
+func (n *Namespace) merge(other *Namespace) {
+	fmt.Println(other)
+	if other.Mapping == nil {
+		other.Mapping = make(map[string]interface{})
+	}
+
+	if n.Mapping == nil {
+		n.Mapping = make(map[string]interface{})
+	}
+	for key, value := range other.Mapping {
+		n.Mapping[key] = value
+	}
+}
+
 // Require will assert that all the specified keys exist in the namespace.
 func (n *Namespace) Require(keys ...string) error {
 	for _, key := range keys {

--- a/namespace.go
+++ b/namespace.go
@@ -30,7 +30,6 @@ func (n *Namespace) KeyExists(key string) bool {
 // merge will take all the values from the other, provided Namespace and copy
 // them to the current Namespace.
 func (n *Namespace) merge(other *Namespace) {
-	fmt.Println(other)
 	if other.Mapping == nil {
 		other.Mapping = make(map[string]interface{})
 	}

--- a/parser.go
+++ b/parser.go
@@ -300,7 +300,7 @@ func (p *Parser) Parse(allArgs ...string) (*Namespace, []string, error) {
 	if len(p.Parsers) > 0 {
 		var usedParser bool
 		if len(allArgs) <= 0 {
-			return p.Namespace, nil, MissingCommandErr{p.Parsers}
+			return p.Namespace, nil, MissingParserErr{p.Parsers}
 		}
 		for name, parser := range p.Parsers {
 			if allArgs[0] == name {
@@ -332,7 +332,7 @@ func (p *Parser) Parse(allArgs ...string) (*Namespace, []string, error) {
 		}
 
 		if usedParser != true {
-			return nil, nil, MissingCommandErr{p.Parsers}
+			return nil, nil, MissingParserErr{p.Parsers}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Curtis La Graff clagraff@amberengine.com

Add the ability to use sub-parsers within a parent parser. Essentially, allowing commands to be used to dictate how the program flow should be routed from the parent parser to any of the available sub-parsers.
