### PR TITLE
added env var defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Upcoming
+## Added
+- Added support for using environmental variable values for the default value
+of options.
 
 # v1.0.1
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # argparse
 ## Project Status
-[ ![Codeship Status for clagraff/argparse](https://codeship.com/projects/68eb7800-af6b-0133-1b97-3e80188314d9/status?branch=master)](https://codeship.com/projects/132507)
+[![CircleCI](https://circleci.com/gh/clagraff/argparse/tree/develop.svg?style=svg)](https://circleci.com/gh/clagraff/argparse/tree/develop)
 [![GoDoc](https://godoc.org/github.com/clagraff/argparse?status.svg)](https://godoc.org/github.com/clagraff/argparse)
 
 ## Description

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,9 +36,9 @@ argparse packaged are included.
     - [ ] Determine & display conflicting options
     - [x] Parse multiple short-arguments in single argument flag
     - [x] Parse from sys.Args by default
-    - [ ] Support sub-parsers / commands
+    - [x] Support sub-parsers / commands
 - [ ] Argument
-    - [ ] Support ARgument attribute functionallity
+    - [x] Support Argument attribute functionallity
         - [x] name
         - [x] action
         - [x] nargs
@@ -52,15 +52,14 @@ argparse packaged are included.
         - [x] dest
     - [x] Support short & long named options
     - [x] Associate short & long named options as single option
-    - [ ] Support Nargs options
+    - [x] Support Nargs options
         - [x] Any positive integer
         - [x] "?" - One argument or none
         - [x] "*" - Any arguments or none
         - [x] "+" - One or more arguments
-        - [ ] "rR" - Remaining arguments
+        - [x] "rR" - Remaining arguments
     - [x] Support argument type-asserting
     - [x] Support limiting to available argument Choices
-    - [ ] Derive Dest attribute from public name
     - [ ] Allow for mutually-exclusive arguments
     - [ ] Provide validity checking for Option based on provided arguments
 - [x] Namespace
@@ -77,7 +76,6 @@ argparse packaged are included.
     - [x] version
 - [ ] Project / General milestones
     - [ ] Documentation / examples
-    - [ ] Unit tests
-        - [ ] Unit testing using Testify package
+    - [x] Unit tests
     - [X] Strong code coverage
     - [X] Comprehensive & cohesive error messages

--- a/actions.go
+++ b/actions.go
@@ -155,7 +155,15 @@ func Append(p *Parser, f *Option, args ...string) ([]string, error) {
 		}
 		return args, nil
 	} else if f.ArgNum == "0" {
-		appendValue(p, f, f.DefaultVal)
+		if isEnvVarFormat(f.DefaultVal) == true {
+			if defVal, err := getEnvVar(f.DefaultVal); err != nil {
+				return args, err
+			} else {
+				appendValue(p, f, defVal)
+			}
+		} else {
+			appendValue(p, f, f.DefaultVal)
+		}
 		return args, nil
 	} else if f.ArgNum == "?" {
 		if len(args) > 0 {
@@ -167,7 +175,15 @@ func Append(p *Parser, f *Option, args ...string) ([]string, error) {
 			appendValue(p, f, args[0])
 			args = args[1:]
 		} else {
-			appendValue(p, f, f.DefaultVal)
+			if isEnvVarFormat(f.DefaultVal) == true {
+				if defVal, err := getEnvVar(f.DefaultVal); err != nil {
+					return args, err
+				} else {
+					appendValue(p, f, defVal)
+				}
+			} else {
+				appendValue(p, f, f.DefaultVal)
+			}
 		}
 	} else if strings.ContainsAny(f.ArgNum, "*+rR") == true {
 		if f.ArgNum == "+" && len(args) == 0 {

--- a/errors.go
+++ b/errors.go
@@ -69,6 +69,18 @@ func (err InvalidTypeErr) Error() string {
 	return fmt.Sprintf(msg, err.opt.DisplayName(), err.opt.ExpectedType.String(), err.arg)
 }
 
+// MissingEnvVarErr indicates that an environmental variable could not be found
+// with the provided variable name.
+type MissingEnvVarErr struct {
+	varName string
+}
+
+// Error will return a string error message for the MissingEnvVarErr.
+func (err MissingEnvVarErr) Error() string {
+	msg := "missing environmental variable \"%s\""
+	return fmt.Sprintf(msg, err.varName)
+}
+
 // ShowHelpErr indicates that the program was instructed to show it's help text.
 type ShowHelpErr struct{}
 

--- a/utils.go
+++ b/utils.go
@@ -69,7 +69,7 @@ func getEnvVar(name string) (string, error) {
 // getScreenWidth returns the width of the screen the program is executed within.
 func getScreenWidth() int {
 	if err := termbox.Init(); err != nil {
-		panic(err) // TODO: This should really be made to return an error.
+		return 80
 	}
 	w, _ := termbox.Size()
 	termbox.Close()

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package argparse
 
 import (
 	"bytes"
+	"os"
 	"regexp"
 	"strings"
 
@@ -54,6 +55,17 @@ func extractOptions(allArgs ...string) (options, args []string) {
 	return options, args
 }
 
+// getEnvVar will attempt to retrieve the value of the environmental
+// variable by the provided name. If the variable cannot be found, an
+// error is returned.
+func getEnvVar(name string) (string, error) {
+	val, found := os.LookupEnv(name[1:])
+	if found != true {
+		return "", MissingEnvVarErr{name}
+	}
+	return val, nil
+}
+
 // getScreenWidth returns the width of the screen the program is executed within.
 func getScreenWidth() int {
 	if err := termbox.Init(); err != nil {
@@ -63,6 +75,21 @@ func getScreenWidth() int {
 	termbox.Close()
 
 	return w
+}
+
+// envVarPattern allows for env variable names that begin with a `$`, and
+// is preceeded by any combination of letters, numbers, or underscores (as
+// long as the first character is a letter).
+var envVarPattern string = `^\$[A-Za-z_][0-9A-Za-z_]*$`
+var envVarRegex *regexp.Regexp = regexp.MustCompile(envVarPattern)
+
+// isEnvVarFormat takes a string and checks if it matches the format
+// of an environmental variable.
+func isEnvVarFormat(text string) bool {
+	if len(text) == 0 || (text[0] != '$' || len(text) == 1) {
+		return false
+	}
+	return envVarRegex.Match([]byte(text))
 }
 
 // join will join the provided strings by the specified delimiter. The delimiter

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package argparse
 
 import (
+	"os"
 	"strings"
 	"testing" //import go package for testing related functionality
 )
@@ -108,6 +109,36 @@ func TestExtractOptions(t *testing.T) {
 	}
 }
 
+// TestGetEnvVar tests to ensure that we can grab the value of a specified
+// environmental variable if it exists, or otherwise error out.
+func TestGetEnvVar(t *testing.T) {
+	key := "FAKE_EXIST_ENV_VAR_1337"
+	val := "value choosen at random"
+	if err := os.Setenv(key, val); err != nil {
+		t.Fatal(err)
+	}
+
+	if str, err := getEnvVar("$" + key); err != nil {
+		t.Errorf(
+			"no error was expected, but an error was returned: %s",
+			err.Error(),
+		)
+	} else {
+		if str != val {
+			t.Errorf(
+				"\"%s\" expected value does not match returned value \"%s\"",
+				val,
+				str,
+			)
+		}
+	}
+
+	key = "FAKE_DOES_NOT_EXIST"
+	if _, err := getEnvVar("$" + key); err == nil {
+		t.Error("An error was expected, but no errors were returned")
+	}
+}
+
 // TestGetScreenWidth tests to ensure that a positive, non-zero integer value is returned
 // to represent the width of the current screen.
 func TestGetScreenWidth(t *testing.T) {
@@ -117,6 +148,42 @@ func TestGetScreenWidth(t *testing.T) {
 	width := getScreenWidth()
 	if width <= 0 {
 		t.Error("Retrieved screen width should be a positive, non-zero integer")
+	}
+}
+
+// TestIsEnvVarFormat is a table-test to ensure that isEnvVarFormat will
+// return the expected result for a given slice of inputs representing
+// possible environmental names.
+func TestIsEnvVarFormat(t *testing.T) {
+	table := map[string]bool{
+		"":                          false,
+		"$":                         false,
+		"$0":                        false,
+		"0":                         false,
+		"_":                         false,
+		"abc":                       false,
+		"DEF":                       false,
+		"VAR$":                      false,
+		"$TEST":                     true,
+		"$abc":                      true,
+		"$FOO_BAR":                  true,
+		"$_":                        true,
+		"$LEET_1337":                true,
+		"$z28":                      true,
+		"$one_222_THREE":            true,
+		"$MANY_______und3rscor3s__": true,
+	}
+
+	for testStr, expectedBool := range table {
+		result := isEnvVarFormat(testStr)
+		if result != expectedBool {
+			t.Errorf(
+				"envVarFormat expected the string \"%s\" to return: %t, but got %t instead",
+				testStr,
+				expectedBool,
+				result,
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to use environmental variable values as stand-in default values for options. It works by specifying the env var name as the default for an option.

For example, if you export a env variable:
```bash
> export MY_BOOL="false"

```

... you can then use the value of that variable during argument parsing by specifiny the env var name as the `Default` value:
```go
...
option.Default("$MY_BOOL")
...
```

Signed-off-by: Curtis La Graff <curtis@amberengine.com>